### PR TITLE
feat: enrich LLM prompts with PR metadata in YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ A GitHub Action that provides automated code review using AI to analyze pull req
 - claude-3-7-sonnet
 - claude-3-5-sonnet
 - gemini-2.0-flash
+- gemini-2.5-flash
+- gemini-2.5-pro
 
 ### My (Subjective) Review of the Particular Models
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ So, based on this **(highly unscientific) scale**:
 - **claude-3-5-sonnet** → **5**
 - **claude-3-7-sonnet** → **6**
 - **gemini-2.0-flash** → **2**
+- **gemini-2.5-pro** → **3**
 
 ## Inputs
 

--- a/prompts/user_prompt.txt
+++ b/prompts/user_prompt.txt
@@ -1,5 +1,7 @@
-Review this pull request diff:
+Review this pull request with the following input (in yaml format) and diff:
 
-```diff
-{{DIFF_CONTENT}}
-```
+{{ INPUT }}
+
+# DIFF
+
+{{ DIFF }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 requests>=2.32.3
 PyGithub>=2.6.1
+pyyaml>=6.0.2
+Jinja2>=3.1.6

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -4,6 +4,7 @@ from unittest import mock
 from unittest.mock import Mock, patch
 
 import pytest
+from jinja2 import Environment
 
 from review import extract_json, get_model, process_review, supported_models
 
@@ -43,6 +44,7 @@ def test_get_model_unsupported_pattern():
 
 
 @patch.object(Path, 'read_text', Mock(return_value='prompt'))
+@patch.object(Environment, 'get_template', Mock(return_value=Mock(render=Mock(return_value='user_prompt'))))
 @patch('requests.post')
 def test_process_review(mock_post):
     """ Test the process_review function """
@@ -65,7 +67,7 @@ def test_process_review(mock_post):
     mock_response.raise_for_status = mock.Mock()
     mock_post.return_value = mock_response
 
-    result = process_review(diff_content, args)
+    result = process_review('title', 'body', diff_content, args, False)
 
     assert result == expected_response
     mock_post.assert_called_once_with(
@@ -80,7 +82,7 @@ def test_process_review(mock_post):
             "model": args.llm_model,
             "messages": [
                 {"role": 'system', "content": "prompt\nprompt"},
-                {"role": "user", "content": "prompt"}
+                {'role': 'user', 'content': 'user_prompt'}
             ]
         }
     )


### PR DESCRIPTION
Switches prompt construction to use Jinja2 templates and YAML-formatted
pull request metadata for clearer, more flexible LLM prompts. Updates
dependencies and test mocks accordingly. Expands support for Gemini 2.5
models. Improves maintainability and review quality through richer and
more structured prompt inputs.