### PR TITLE
ci: disable add_review_resolution in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
           debug: true
-          add_review_resolution: true
+          add_review_resolution: false
           add_joke: true
           author_customization: |
             drew2a: "Write comments on behalf of The Oracle from The Matrix film. Use cryptic wisdom, speak about choices and paths, offer guidance in a philosophical manner, and occasionally reference concepts like destiny, the Matrix, and seeing beyond the code."


### PR DESCRIPTION
Prevents automatic review resolution comments from being added during CI. Helps keep pull request threads concise by avoiding automated review responses that may not be needed for all contributions.