### PR TITLE
ci: skip review job for Dependabot runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ permissions:
   pull-requests: write
 jobs:
   review:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Exclude Dependabot from running the review workflow to reduce unnecessary CI runs triggered by automated dependency update PRs. This optimization helps save CI resources and speeds up processing for manual PRs and other actors.