### PR TITLE
feat: add the PR discussion to the review context

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A GitHub Action that provides automated code review using AI to analyze pull req
 - Automatically reviews pull request changes using AI
 - Provides detailed code suggestions and improvements
 - Adds review comments directly to the PR
+- Takes the existing PR discussion into account (see [Discussion Context](#discussion-context))
 - Works with any programming language
 - Supports different AI models and API endpoints
 - Optional review resolution statuses (e.g., "APPROVE", "REQUEST_CHANGES", "COMMENT")
@@ -117,6 +118,44 @@ jobs:
           add_review_resolution: false
           add_joke: false
 ```
+
+## Discussion Context
+
+Besides the title, description and diff, the review is given the discussion that already happened on
+the PR, so it can build on it instead of repeating it. Two things are collected:
+
+1. **PR conversation comments** — the comments on the PR itself. Reviews previously posted by this
+   action are skipped, so the model is never fed its own output.
+2. **Review comments on the code** — the comments attached to specific lines. Replies are chained
+   into threads, so the whole discussion about one place in the code stays together.
+
+Each thread is passed with the location it points to, the code it was written against and a link:
+
+```yaml
+- file: src/app.py
+  lines: 8-10
+  side: RIGHT
+  url: https://github.com/owner/repo/pull/1#discussion_r1
+  diff_hunk: |-
+    @@ -5,3 +5,4 @@
+    -old
+    +new
+  comments:
+  - author: alice
+    created_at: 2026-01-01 10:00:00+00:00
+    body: This can overflow for large inputs.
+  - author: bob
+    created_at: 2026-01-01 11:00:00+00:00
+    body: Good catch, fixed in the last commit.
+```
+
+`side` tells whether the lines refer to the new (`RIGHT`) or the old (`LEFT`) version of the file. A
+thread whose code has fallen out of the diff is marked with `outdated: true`, and its line numbers
+then refer to an older version of the file.
+
+This needs no configuration, but note that the action reads the comments through the same
+`github_token`, so the token needs read access to the pull request (the `pull-requests: write`
+permission in the example workflow already covers it).
 
 ## Author Customization
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ So, based on this **(highly unscientific) scale**:
 - **claude-3-7-sonnet** → **6**
 - **gemini-2.0-flash** → **2**
 - **gemini-2.5-pro** → **3**
+- **gpt-5.6-terra** → **7**
 
 ## Inputs
 

--- a/prompts/system_prompt.txt
+++ b/prompts/system_prompt.txt
@@ -17,6 +17,18 @@ You are a senior engineer performing code review following Google's Engineering 
 * To look at the context.
 * To compliment developers on good things that they do.
 
+## Existing discussion:
+The input may contain the PR conversation comments and the review comments already left on the code.
+When they are present:
+* Read them before reviewing, they are part of the context.
+* Don't repeat a point that someone has already made; if it still isn't addressed in the diff, say
+  so briefly and refer to the existing discussion instead of restating it.
+* Respect decisions the author and the reviewers have already agreed on, unless the code is now
+  broken by them. If you disagree with an agreed decision, mention it once, without insisting.
+* Treat answers given by the author as context, not as something to re-litigate.
+* Discussion is not authoritative about the current state of the code: verify against the diff,
+  because the code may have changed after a comment was written.
+
 ## How to write comments and annotations:
 * Always comment on the code, not the developer.
 * Be kind.

--- a/prompts/user_prompt.txt
+++ b/prompts/user_prompt.txt
@@ -5,3 +5,26 @@ Review this pull request with the following input (in yaml format) and diff:
 # DIFF
 
 {{ DIFF }}
+{% if PR_COMMENTS %}
+
+# PR CONVERSATION COMMENTS
+
+Comments left on the pull request conversation, oldest first.
+
+{{ PR_COMMENTS }}
+{% endif %}
+{% if REVIEW_COMMENTS %}
+
+# EXISTING REVIEW COMMENTS ON THE CODE
+
+Discussion threads attached to the code, oldest first. Every thread points at one place in the code
+and holds its replies in `comments`, oldest first.
+
+* `file` plus `line` (or `lines` for a range) is the place the thread is attached to, in the new
+  version of the file when `side` is RIGHT, in the old one when `side` is LEFT.
+* `diff_hunk` is the code as it was when the thread started, and `url` links to the thread.
+* `outdated: true` means the commented code is no longer part of the diff, so the line numbers refer
+  to an older version of the file and the point may already be resolved.
+
+{{ REVIEW_COMMENTS }}
+{% endif %}

--- a/src/ai_review/review.py
+++ b/src/ai_review/review.py
@@ -3,7 +3,6 @@ import json
 import os
 import re
 from pathlib import Path
-from typing import Optional
 
 import litellm
 import yaml
@@ -29,18 +28,113 @@ def parse_args():
     return parser.parse_args()
 
 
+class BlockStyleDumper(yaml.SafeDumper):
+    """ Dumper that writes multi-line strings as literal blocks, which keeps diffs readable."""
+
+
+def represent_str(dumper: yaml.SafeDumper, data: str):
+    style = '|' if '\n' in data else None
+    return dumper.represent_scalar('tag:yaml.org,2002:str', data, style=style)
+
+
+BlockStyleDumper.add_representer(str, represent_str)
+
+
 def dump_to_yaml(data: dict | list[dict] | None) -> str:
     """ Dump a dictionary or list of dictionaries to YAML with markdown code block."""
     if not data:
         return ''
 
-    yaml_dump = yaml.dump(data, allow_unicode=True, sort_keys=False)
+    yaml_dump = yaml.dump(data, Dumper=BlockStyleDumper, allow_unicode=True, sort_keys=False)
 
     return f'```yaml\n{yaml_dump}```'
 
 
-def process_review(title: str, body: Optional[str], diff_string, pr_author: str, args, debug):
-    """ Calls the LLM API to generate a review based on the PR title, body, and diff."""
+def is_previous_ai_review(comment) -> bool:
+    """ Check whether a comment is a review previously posted by this action."""
+    user = comment.user
+    return bool(comment.body) and HEADER in comment.body and bool(user) and user.login == GITHUB_ACTIONS_BOT
+
+
+def collect_pr_comments(pr) -> list[dict]:
+    """
+    Collect the comments of the PR conversation.
+
+    Reviews previously posted by this action are skipped, so the LLM is not fed its own output.
+    """
+    return [
+        {
+            'author': comment.user.login if comment.user else '',
+            'created_at': str(comment.created_at),
+            'body': comment.body,
+        }
+        for comment in pr.get_issue_comments()
+        if not is_previous_ai_review(comment)
+    ]
+
+
+def describe_comment_location(comment) -> dict:
+    """
+    Describe which lines of which file a review comment points to.
+
+    `line` is the last line of the commented range and `start_line` the first one, both in the new
+    version of the file unless `side` is LEFT. GitHub sets them to None once the commented code
+    falls out of the diff, leaving only the `original_*` values.
+    """
+    line = comment.line if comment.line is not None else comment.original_line
+    start_line = comment.start_line if comment.start_line is not None else comment.original_start_line
+
+    location = {'file': comment.path}
+    if start_line and start_line != line:
+        location['lines'] = f'{start_line}-{line}'
+    else:
+        location['line'] = line
+    location['side'] = comment.side or 'RIGHT'
+    if comment.line is None:
+        location['outdated'] = True
+
+    return location
+
+
+def collect_review_comments(pr) -> list[dict]:
+    """
+    Collect the review comments left on the code, grouped into threads.
+
+    Replies are chained under the comment that started the thread, so the discussion of a single
+    place in the code stays together. Each thread also carries the `diff_hunk` it was written
+    against, because a comment is only meaningful together with the code it points to.
+    """
+    threads: dict[int, dict] = {}
+    root_ids: dict[int, int] = {}
+
+    for comment in pr.get_review_comments():
+        parent_id = comment.in_reply_to_id
+        # Comments arrive oldest first, so a parent is always resolved before its replies.
+        root_id = root_ids.get(parent_id, parent_id) if parent_id else comment.id
+        root_ids[comment.id] = root_id
+
+        thread = threads.get(root_id)
+        if thread is None:
+            thread = threads[root_id] = {
+                **describe_comment_location(comment),
+                'url': comment.html_url,
+                'diff_hunk': comment.diff_hunk,
+                'comments': [],
+            }
+
+        thread['comments'].append({
+            'author': comment.user.login if comment.user else '',
+            'created_at': str(comment.created_at),
+            'body': comment.body,
+        })
+
+    return list(threads.values())
+
+
+def process_review(title: str, body: str | None, diff_string, pr_author: str, args, debug,
+                   pr_comments: list[dict] | None = None,
+                   review_comments: list[dict] | None = None):
+    """ Calls the LLM API to generate a review based on the PR title, body, diff and comments."""
 
     system_prompt = Path('/app/prompts/system_prompt.txt').read_text()
     if args.add_joke.lower() == 'true':
@@ -66,7 +160,9 @@ def process_review(title: str, body: Optional[str], diff_string, pr_author: str,
             'pr_body': body,
             'pr_author': pr_author,
         }),
-        'DIFF': diff_string
+        'DIFF': diff_string,
+        'PR_COMMENTS': dump_to_yaml(pr_comments),
+        'REVIEW_COMMENTS': dump_to_yaml(review_comments),
     }
 
     user_template = env.get_template('user_prompt.txt')
@@ -148,7 +244,7 @@ def publish_annotations(summary_content, github_token, debug, llm_model, add_rev
     # Delete previous comments from GitHub Actions that include the HEADER
     for comment in pr.get_issue_comments():
         print(comment.user.login)
-        if HEADER in comment.body and comment.user.login == GITHUB_ACTIONS_BOT:
+        if is_previous_ai_review(comment):
             comment.delete()
 
     if human_summary:
@@ -196,7 +292,7 @@ def help_llm(diff_file: File):
             current_line_number = int(match.group(1))
             output_lines.append(line)
         else:
-            if line.startswith(" ") or line.startswith("+"):
+            if line.startswith((" ", "+")):
                 if current_line_number is not None:
                     annotated_line = f"{current_line_number:4d}: {line}"
                     current_line_number += 1
@@ -214,7 +310,7 @@ def help_llm(diff_file: File):
 def extract_json(text):
     if not text:
         return text
-    return re.search(r'\{.*\}', text, re.S).group(0)
+    return re.search(r'\{.*\}', text, re.DOTALL).group(0)
 
 
 def parse_author_customization(customization_yaml: str):
@@ -253,8 +349,12 @@ if __name__ == "__main__":
     )
     debug = args.debug.lower() == 'true'
 
+    pr_comments = collect_pr_comments(pr)
+    review_comments = collect_review_comments(pr)
+
     add_review_resolution = args.add_review_resolution.lower() == 'true'
-    review_content = process_review(pr.title, pr.body, diff_string, pr_author, args, debug)
+    review_content = process_review(pr.title, pr.body, diff_string, pr_author, args, debug,
+                                    pr_comments=pr_comments, review_comments=review_comments)
 
     llm_model = os.environ.get('LLM_MODEL')
     publish_annotations(review_content, args.github_token, debug, llm_model, add_review_resolution)

--- a/src/ai_review/tests/test_review.py
+++ b/src/ai_review/tests/test_review.py
@@ -9,10 +9,14 @@ from unittest.mock import Mock, patch
 from jinja2 import Environment
 
 from ai_review.review import (
+    collect_pr_comments,
+    collect_review_comments,
+    describe_comment_location,
     dump_to_yaml,
     extract_json,
     get_author_specific_prompt_additions,
     help_llm,
+    is_previous_ai_review,
     parse_args,
     parse_author_customization,
     process_review,
@@ -155,6 +159,13 @@ def test_dump_to_yaml_empty():
     assert dump_to_yaml([]) == ''
 
 
+def test_dump_to_yaml_multiline_string_as_block():
+    """Multi-line strings are dumped as literal blocks instead of folded quoted scalars."""
+    result = dump_to_yaml({'diff_hunk': '@@ -5,3 +5,4 @@\n-old\n+new'})
+
+    assert result == '```yaml\ndiff_hunk: |-\n  @@ -5,3 +5,4 @@\n  -old\n  +new\n```'
+
+
 def test_dump_to_yaml_with_data():
     result = dump_to_yaml({'key': 'value'})
     assert '```yaml' in result
@@ -240,6 +251,211 @@ def test_help_llm_other_line():
     assert '\\ No newline at end of file' in result
 
 
+def _issue_comment(author: str, body: str, created_at: str = '2026-01-01 10:00:00'):
+    comment = Mock()
+    comment.user = Mock(login=author)
+    comment.body = body
+    comment.created_at = created_at
+    return comment
+
+
+def _review_comment(comment_id: int, author: str, body: str, path: str = 'foo.py', line: int = 10,
+                    start_line=None, side: str = 'RIGHT', in_reply_to_id=None,
+                    original_line: int = 7, original_start_line=None):
+    comment = Mock()
+    comment.id = comment_id
+    comment.user = Mock(login=author)
+    comment.body = body
+    comment.created_at = '2026-01-01 10:00:00'
+    comment.path = path
+    comment.line = line
+    comment.start_line = start_line
+    comment.original_line = original_line
+    comment.original_start_line = original_start_line
+    comment.side = side
+    comment.in_reply_to_id = in_reply_to_id
+    comment.diff_hunk = '@@ -1,2 +1,2 @@\n-old\n+new'
+    comment.html_url = f'https://github.com/owner/repo/pull/1#discussion_r{comment_id}'
+    return comment
+
+
+def test_is_previous_ai_review():
+    assert is_previous_ai_review(_issue_comment('github-actions[bot]', '# AI Review\n\nsummary'))
+    assert not is_previous_ai_review(_issue_comment('someuser', '# AI Review\n\nsummary'))
+    assert not is_previous_ai_review(_issue_comment('github-actions[bot]', 'unrelated bot output'))
+
+
+def test_is_previous_ai_review_without_body_or_user():
+    assert not is_previous_ai_review(_issue_comment('github-actions[bot]', None))
+
+    comment = _issue_comment('github-actions[bot]', '# AI Review')
+    comment.user = None
+    assert not is_previous_ai_review(comment)
+
+
+def test_collect_pr_comments():
+    pr = Mock()
+    pr.get_issue_comments.return_value = [
+        _issue_comment('alice', 'Please rename this', '2026-01-01 10:00:00'),
+        _issue_comment('github-actions[bot]', '# AI Review\n\nprevious review'),
+        _issue_comment('bob', 'Agreed, renamed', '2026-01-02 11:00:00'),
+    ]
+
+    assert collect_pr_comments(pr) == [
+        {'author': 'alice', 'created_at': '2026-01-01 10:00:00', 'body': 'Please rename this'},
+        {'author': 'bob', 'created_at': '2026-01-02 11:00:00', 'body': 'Agreed, renamed'},
+    ]
+
+
+def test_collect_pr_comments_empty():
+    pr = Mock()
+    pr.get_issue_comments.return_value = []
+    assert collect_pr_comments(pr) == []
+
+
+def test_collect_pr_comments_without_user():
+    pr = Mock()
+    comment = _issue_comment('alice', 'orphaned comment')
+    comment.user = None
+    pr.get_issue_comments.return_value = [comment]
+
+    assert collect_pr_comments(pr) == [
+        {'author': '', 'created_at': '2026-01-01 10:00:00', 'body': 'orphaned comment'},
+    ]
+
+
+def test_collect_review_comments_chains_replies_into_threads():
+    pr = Mock()
+    pr.get_review_comments.return_value = [
+        _review_comment(1, 'alice', 'This can overflow'),
+        _review_comment(2, 'bob', 'Good catch', in_reply_to_id=1),
+        # A reply to a reply: GitHub may point it at the previous reply, not at the thread root.
+        _review_comment(3, 'alice', 'Fixed in the last commit', in_reply_to_id=2),
+        _review_comment(4, 'carol', 'Unrelated place', path='bar.py', line=42),
+    ]
+
+    threads = collect_review_comments(pr)
+
+    assert len(threads) == 2
+    assert [c['body'] for c in threads[0]['comments']] == [
+        'This can overflow', 'Good catch', 'Fixed in the last commit'
+    ]
+    assert threads[0]['file'] == 'foo.py'
+    assert threads[0]['line'] == 10
+    assert threads[0]['url'] == 'https://github.com/owner/repo/pull/1#discussion_r1'
+    assert threads[0]['comments'][0] == {
+        'author': 'alice', 'created_at': '2026-01-01 10:00:00', 'body': 'This can overflow'
+    }
+    assert threads[1]['file'] == 'bar.py'
+    assert threads[1]['line'] == 42
+    assert [c['body'] for c in threads[1]['comments']] == ['Unrelated place']
+
+
+def test_collect_review_comments_reply_to_unknown_parent():
+    """A reply whose parent is missing (e.g. deleted) still gets a thread of its own."""
+    pr = Mock()
+    pr.get_review_comments.return_value = [_review_comment(2, 'bob', 'Good catch', in_reply_to_id=1)]
+
+    threads = collect_review_comments(pr)
+
+    assert len(threads) == 1
+    assert [c['body'] for c in threads[0]['comments']] == ['Good catch']
+
+
+def test_collect_review_comments_empty():
+    pr = Mock()
+    pr.get_review_comments.return_value = []
+    assert collect_review_comments(pr) == []
+
+
+def test_collect_review_comments_without_user():
+    pr = Mock()
+    pr.get_review_comments.return_value = [_review_comment(1, 'alice', 'orphaned')]
+    pr.get_review_comments.return_value[0].user = None
+
+    assert collect_review_comments(pr)[0]['comments'][0]['author'] == ''
+
+
+def test_describe_comment_location_single_line():
+    location = describe_comment_location(_review_comment(1, 'alice', 'body', line=10))
+    assert location == {'file': 'foo.py', 'line': 10, 'side': 'RIGHT'}
+
+
+def test_describe_comment_location_range():
+    comment = _review_comment(1, 'alice', 'body', line=10, start_line=8)
+    assert describe_comment_location(comment) == {'file': 'foo.py', 'lines': '8-10', 'side': 'RIGHT'}
+
+
+def test_describe_comment_location_left_side():
+    comment = _review_comment(1, 'alice', 'body', side='LEFT')
+    assert describe_comment_location(comment)['side'] == 'LEFT'
+
+
+def test_describe_comment_location_missing_side():
+    comment = _review_comment(1, 'alice', 'body', side=None)
+    assert describe_comment_location(comment)['side'] == 'RIGHT'
+
+
+def test_describe_comment_location_outdated():
+    """Once the code falls out of the diff, GitHub keeps only the original_* line numbers."""
+    comment = _review_comment(1, 'alice', 'body', line=None, original_line=7, original_start_line=5)
+
+    assert describe_comment_location(comment) == {
+        'file': 'foo.py', 'lines': '5-7', 'side': 'RIGHT', 'outdated': True
+    }
+
+
+def test_process_review_includes_comments():
+    render = Mock(return_value='user_prompt')
+    args = argparse.Namespace(
+        github_token='gh_token',
+        debug='false',
+        add_review_resolution='false',
+        add_joke='false',
+        author_customization='',
+    )
+    mock_response = mock.Mock()
+    mock_response.choices = [mock.Mock(message=mock.Mock(content='Review'))]
+
+    pr_comments = [{'author': 'alice', 'created_at': '2026-01-01', 'body': 'Please rename this'}]
+    review_comments = [{'file': 'foo.py', 'line': 10, 'comments': [{'body': 'This can overflow'}]}]
+
+    with patch.object(Path, 'read_text', Mock(return_value='system prompt')), \
+         patch.object(Environment, 'get_template', Mock(return_value=Mock(render=render))), \
+         patch('litellm.completion', return_value=mock_response), \
+         patch.dict(os.environ, {'LLM_MODEL': 'gpt-4o'}):
+        process_review('title', 'body', 'diff', 'author', args, False,
+                       pr_comments=pr_comments, review_comments=review_comments)
+
+    context = render.call_args[1]
+    assert 'Please rename this' in context['PR_COMMENTS']
+    assert 'This can overflow' in context['REVIEW_COMMENTS']
+
+
+def test_process_review_without_comments():
+    """With no comments, the template variables are empty so their sections are skipped."""
+    render = Mock(return_value='user_prompt')
+    args = argparse.Namespace(
+        github_token='gh_token',
+        debug='false',
+        add_review_resolution='false',
+        add_joke='false',
+        author_customization='',
+    )
+    mock_response = mock.Mock()
+    mock_response.choices = [mock.Mock(message=mock.Mock(content='Review'))]
+
+    with patch.object(Path, 'read_text', Mock(return_value='system prompt')), \
+         patch.object(Environment, 'get_template', Mock(return_value=Mock(render=render))), \
+         patch('litellm.completion', return_value=mock_response), \
+         patch.dict(os.environ, {'LLM_MODEL': 'gpt-4o'}):
+        process_review('title', 'body', 'diff', 'author', args, False)
+
+    context = render.call_args[1]
+    assert context['PR_COMMENTS'] == ''
+    assert context['REVIEW_COMMENTS'] == ''
+
+
 def _make_github_mock():
     mock_github_instance = Mock()
     mock_repo = Mock()
@@ -295,7 +511,7 @@ def test_publish_annotations_without_marker():
 
 def test_publish_annotations_invalid_annotations_json(capsys):
     content = 'Human summary\n### TECHNICAL INFORMATION\n{invalid json}'
-    mock_gh, mock_pr = _make_github_mock()
+    mock_gh, _ = _make_github_mock()
 
     with patch('ai_review.review.Github', return_value=mock_gh), \
          patch('ai_review.review.github_ref', _GITHUB_REF), \
@@ -381,7 +597,7 @@ def test_publish_annotations_no_review_data():
 
 def test_publish_annotations_invalid_review_json(capsys):
     content = 'Human summary\n### TECHNICAL INFORMATION\n{invalid json}'
-    mock_gh, mock_pr = _make_github_mock()
+    mock_gh, _ = _make_github_mock()
 
     with patch('ai_review.review.Github', return_value=mock_gh), \
          patch('ai_review.review.github_ref', _GITHUB_REF), \
@@ -402,12 +618,14 @@ def test_main_block():
     mock_file.patch = '@@ -1,2 +1,2 @@\n context\n+added'
     mock_file.filename = 'test.py'
     mock_pr.get_files.return_value = [mock_file]
-    mock_pr.get_issue_comments.return_value = []
+    mock_pr.get_issue_comments.return_value = [_issue_comment('alice', 'Please rename this')]
+    mock_pr.get_review_comments.return_value = [_review_comment(1, 'bob', 'This can overflow')]
     mock_github_instance.get_repo.return_value = mock_repo
     mock_repo.get_pull.return_value = mock_pr
 
     mock_response = Mock()
     mock_response.choices = [Mock(message=Mock(content='Review content'))]
+    render = Mock(return_value='user prompt')
 
     with patch('sys.argv', ['review.py', 'gh_token', 'false', 'false', 'false', '']), \
          patch.dict(os.environ, {
@@ -418,7 +636,11 @@ def test_main_block():
          patch('github.Github', return_value=mock_github_instance), \
          patch('litellm.completion', return_value=mock_response), \
          patch('pathlib.Path.read_text', return_value='system prompt'), \
-         patch.object(Environment, 'get_template', return_value=Mock(render=Mock(return_value='user prompt'))):
+         patch.object(Environment, 'get_template', return_value=Mock(render=render)):
         runpy.run_module('ai_review.review', run_name='__main__')
 
     mock_pr.create_issue_comment.assert_called()
+
+    context = render.call_args[1]
+    assert 'Please rename this' in context['PR_COMMENTS']
+    assert 'This can overflow' in context['REVIEW_COMMENTS']


### PR DESCRIPTION
## Why

The review only saw the title, body and diff, so it kept raising points that had already been discussed on the PR.

## What

Two sources of discussion are now collected and passed to the model:

1. **PR conversation comments** — reviews this action posted earlier are skipped, so the model is never fed its own output.
2. **Comments on the code** — grouped into threads.

Each thread carries the place it points to, the code it was written against and a link:

```yaml
- file: src/app.py
  lines: 8-10
  side: RIGHT
  url: https://github.com/owner/repo/pull/1#discussion_r1
  diff_hunk: |-
    @@ -5,3 +5,4 @@
    -old
    +new
  comments:
  - author: alice
    created_at: 2026-01-01 10:00:00+00:00
    body: This can overflow for large inputs.
  - author: bob
    created_at: 2026-01-01 11:00:00+00:00
    body: Good catch, fixed in the last commit.
```

- `line`, or `lines` for a multi-line comment; `side` says whether they refer to the new (`RIGHT`) or old (`LEFT`) version of the file.
- A thread whose code fell out of the diff keeps the `original_*` line numbers and is marked `outdated: true` — which usually means the point is already resolved.
- Replies are chained under the comment that started the thread. Parents resolve transitively, so a reply to a reply stays in the same thread instead of starting a new one.

The system prompt now tells the reviewer to build on that discussion rather than repeat it, to respect decisions already agreed, and to verify against the diff — the discussion is not authoritative about the current state of the code.

Both sections are omitted from the prompt entirely when there are no comments. No new inputs; the existing `github_token` already has the required read access.

## Beyond the ask

- `dump_to_yaml` now writes multi-line strings as YAML block literals (`|-`). Folded quoted scalars turned every diff hunk into doubled blank lines. This also fixes multi-line PR bodies, which had the same problem.
- Fixed 5 pre-existing ruff violations in the two touched files (`Optional[X]`, a `startswith` pair, `re.S`, two unused unpacks). Not introduced here, but ruff CI lints changed files and both files would have gone red.