### PR TITLE
feat: post real inline review comments and skip outdated threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ A GitHub Action that provides automated code review using AI to analyze pull req
 
 - Automatically reviews pull request changes using AI
 - Provides detailed code suggestions and improvements
-- Adds review comments directly to the PR
+- Posts real review comments attached to the changed lines, plus a summary comment on the PR
+- Remembers its own previous comments, so re-running the review does not repeat them
 - Takes the existing PR discussion into account (see [Discussion Context](#discussion-context))
 - Works with any programming language
 - Supports different AI models and API endpoints
@@ -125,10 +126,12 @@ jobs:
 Besides the title, description and diff, the review is given the discussion that already happened on
 the PR, so it can build on it instead of repeating it. Two things are collected:
 
-1. **PR conversation comments** — the comments on the PR itself. Reviews previously posted by this
-   action are skipped, so the model is never fed its own output.
+1. **PR conversation comments** — the comments on the PR itself. Summaries previously posted by
+   this action are skipped, because they are replaced by the new summary anyway.
 2. **Review comments on the code** — the comments attached to specific lines. Replies are chained
-   into threads, so the whole discussion about one place in the code stays together.
+   into threads, so the whole discussion about one place in the code stays together. Comments the
+   action itself left on previous runs are included on purpose: the model is told they are its own,
+   which keeps it from repeating them.
 
 Each thread is passed with the location it points to, the code it was written against and a link:
 
@@ -151,8 +154,9 @@ Each thread is passed with the location it points to, the code it was written ag
 ```
 
 `side` tells whether the lines refer to the new (`RIGHT`) or the old (`LEFT`) version of the file. A
-thread whose code has fallen out of the diff is marked with `outdated: true`, and its line numbers
-then refer to an older version of the file.
+thread whose code has fallen out of the diff (for example because the author pushed a fix) is
+considered outdated and is left out of the context, since its line numbers would refer to an older
+version of the file.
 
 This needs no configuration, but note that the action reads the comments through the same
 `github_token`, so the token needs read access to the pull request (the `pull-requests: write`

--- a/prompts/system_prompt.txt
+++ b/prompts/system_prompt.txt
@@ -21,6 +21,10 @@ You are a senior engineer performing code review following Google's Engineering 
 The input may contain the PR conversation comments and the review comments already left on the code.
 When they are present:
 * Read them before reviewing, they are part of the context.
+* Review comments authored by `github-actions[bot]` are your own comments from previous runs of
+  this review. Never output a comment that repeats one of them: if the point still stands, it is
+  already visible in the existing thread. Comment on the same place again only when the code
+  around it has changed and you have something new to say.
 * Don't repeat a point that someone has already made; if it still isn't addressed in the diff, say
   so briefly and refer to the existing discussion instead of restating it.
 * Respect decisions the author and the reviewers have already agreed on, unless the code is now
@@ -50,19 +54,21 @@ To ensure reliable parsing, after your review summary, output a unique marker li
 Immediately following this marker, output the JSON object exactly as specified below.
 The JSON object must have the following structure:
 {
-  "annotations": [ ... ],
+  "comments": [ ... ],
   "review": {
       "resolution": "<APPROVE|REQUEST_CHANGES|COMMENT>",
       "review_message": "<review text>"
   }
 }
 
-The "annotations" key must be an array of annotation objects. Each annotation object must have:
+The "comments" key must be an array of comment objects. Each one is posted on the pull request as
+a real review comment attached to the code, so write its message as regular Markdown addressed to
+the author. Each comment object must have:
 - "file": the full path to the file.
-- "line": the exact line number.
-- "message": a message following the format:
-  `<label> [decorations]: <subject>%0A%0Asuggestion: <suggestion>`
-  where:
+- "line": the exact line number the comment points to. It must be one of the numbered lines of the
+  diff, i.e. a line of the new version of the file; a comment pointing anywhere else is dropped.
+- "message": a Markdown message following the format:
+  `<label> [decorations]: <subject>` followed by a blank line and the suggestion, where:
     - label: a single label that signifies the comment type.
     - decorations (optional): extra decorating labels in parentheses, comma-separated.
     - subject: the main message (remember you are a senior engineer performing code review following Google's Engineering Practices).
@@ -70,8 +76,8 @@ The "annotations" key must be an array of annotation objects. Each annotation ob
 
 Example:
 {
-  "annotations": [
-    {"file": "example.js", "line": 10, "message": "bug [urgent]: Incorrect variable naming (Consider renaming to improve readability)%0A%0Asuggestion: Rename variable 'x' to a more descriptive name such as 'userCount' to better reflect its purpose in the code."}
+  "comments": [
+    {"file": "example.js", "line": 10, "message": "bug [urgent]: Incorrect variable naming (Consider renaming to improve readability)\n\nsuggestion: Rename variable 'x' to a more descriptive name such as 'userCount' to better reflect its purpose in the code."}
   ],
   "review": {
       "resolution": "REQUEST_CHANGES",

--- a/prompts/user_prompt.txt
+++ b/prompts/user_prompt.txt
@@ -23,8 +23,8 @@ and holds its replies in `comments`, oldest first.
 * `file` plus `line` (or `lines` for a range) is the place the thread is attached to, in the new
   version of the file when `side` is RIGHT, in the old one when `side` is LEFT.
 * `diff_hunk` is the code as it was when the thread started, and `url` links to the thread.
-* `outdated: true` means the commented code is no longer part of the diff, so the line numbers refer
-  to an older version of the file and the point may already be resolved.
+* Comments authored by `github-actions[bot]` are your own, left by previous runs of this review.
+* Threads on code that is no longer part of the diff are excluded.
 
 {{ REVIEW_COMMENTS }}
 {% endif %}

--- a/src/ai_review/review.py
+++ b/src/ai_review/review.py
@@ -6,11 +6,14 @@ from pathlib import Path
 
 import litellm
 import yaml
-from github import File, Github
+from github import File, Github, GithubException
 from jinja2 import Environment, FileSystemLoader
 
 GITHUB_ACTIONS_BOT = 'github-actions[bot]'
 HEADER = '# AI Review'
+REVIEW_RESOLUTIONS = ('APPROVE', 'REQUEST_CHANGES', 'COMMENT')
+
+HUNK_HEADER_RE = re.compile(r'^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@')
 
 # Environment variables set by GitHub Actions
 github_ref = os.environ.get('GITHUB_REF')
@@ -78,20 +81,14 @@ def describe_comment_location(comment) -> dict:
     Describe which lines of which file a review comment points to.
 
     `line` is the last line of the commented range and `start_line` the first one, both in the new
-    version of the file unless `side` is LEFT. GitHub sets them to None once the commented code
-    falls out of the diff, leaving only the `original_*` values.
+    version of the file unless `side` is LEFT.
     """
-    line = comment.line if comment.line is not None else comment.original_line
-    start_line = comment.start_line if comment.start_line is not None else comment.original_start_line
-
     location = {'file': comment.path}
-    if start_line and start_line != line:
-        location['lines'] = f'{start_line}-{line}'
+    if comment.start_line and comment.start_line != comment.line:
+        location['lines'] = f'{comment.start_line}-{comment.line}'
     else:
-        location['line'] = line
+        location['line'] = comment.line
     location['side'] = comment.side or 'RIGHT'
-    if comment.line is None:
-        location['outdated'] = True
 
     return location
 
@@ -103,9 +100,14 @@ def collect_review_comments(pr) -> list[dict]:
     Replies are chained under the comment that started the thread, so the discussion of a single
     place in the code stays together. Each thread also carries the `diff_hunk` it was written
     against, because a comment is only meaningful together with the code it points to.
+
+    Threads on code that is no longer part of the diff (GitHub clears their `line`) are dropped:
+    their line numbers refer to an older version of the file, so they would only mislead the LLM
+    about the current state of the code.
     """
     threads: dict[int, dict] = {}
     root_ids: dict[int, int] = {}
+    outdated_roots: set[int] = set()
 
     for comment in pr.get_review_comments():
         parent_id = comment.in_reply_to_id
@@ -113,8 +115,14 @@ def collect_review_comments(pr) -> list[dict]:
         root_id = root_ids.get(parent_id, parent_id) if parent_id else comment.id
         root_ids[comment.id] = root_id
 
+        if root_id in outdated_roots:
+            continue
+
         thread = threads.get(root_id)
         if thread is None:
+            if comment.line is None:
+                outdated_roots.add(root_id)
+                continue
             thread = threads[root_id] = {
                 **describe_comment_location(comment),
                 'url': comment.html_url,
@@ -188,7 +196,57 @@ def process_review(title: str, body: str | None, diff_string, pr_author: str, ar
     return response.choices[0].message.content
 
 
-def publish_annotations(summary_content, github_token, debug, llm_model, add_review_resolution):
+def collect_commentable_lines(diff_files) -> dict[str, set[int]]:
+    """
+    Map each file of the diff to the line numbers a review comment can be attached to.
+
+    Those are the lines of the new version of the file that appear in the diff: added lines and
+    unchanged context lines. GitHub rejects a review whose comment points anywhere else.
+    """
+    commentable: dict[str, set[int]] = {}
+
+    for diff_file in diff_files:
+        lines = commentable.setdefault(diff_file.filename, set())
+        if not diff_file.patch:
+            continue
+        current_line_number = None
+        for line in diff_file.patch.splitlines():
+            match = HUNK_HEADER_RE.match(line)
+            if match:
+                current_line_number = int(match.group(1))
+            elif line.startswith((' ', '+')) and current_line_number is not None:
+                lines.add(current_line_number)
+                current_line_number += 1
+
+    return commentable
+
+
+def build_inline_comments(comments: list[dict], commentable_lines: dict[str, set[int]]) -> list[dict]:
+    """
+    Convert the comments of the LLM output into GitHub review comments.
+
+    A comment that does not point at a commentable line of the diff is dropped, because a single
+    misplaced comment would make GitHub reject the whole review.
+    """
+    inline_comments = []
+    for comment in comments:
+        filename = comment.get('file')
+        message = comment.get('message')
+        try:
+            line = int(comment.get('line'))
+        except (TypeError, ValueError):
+            line = None
+
+        if not filename or not message or line not in commentable_lines.get(filename, set()):
+            print(f'Skipping comment that does not point at the diff: {comment}')
+            continue
+
+        inline_comments.append({'path': filename, 'line': line, 'side': 'RIGHT', 'body': message})
+
+    return inline_comments
+
+
+def publish_review(summary_content, github_token, debug, llm_model, add_review_resolution):
     """
     Splits the LLM response into two parts:
       1. The human-readable summary (before the marker).
@@ -196,7 +254,7 @@ def publish_annotations(summary_content, github_token, debug, llm_model, add_rev
 
     The technical information must be a JSON block with the following structure:
     {
-      "annotations": [ ... ],
+      "comments": [ {"file": "<path>", "line": <line>, "message": "<markdown>"}, ... ],
       "review": {
           "resolution": "<APPROVE|REQUEST_CHANGES|COMMENT>",
           "review_message": "<review text>"
@@ -204,9 +262,12 @@ def publish_annotations(summary_content, github_token, debug, llm_model, add_rev
     }
 
     The function then:
-      - Prints annotations in the format ::warning file={filename},line={line}::{message}
-      - Posts an issue comment with the summary in the PR.
-      - If a review block is present, submits a PR review via the GitHub API.
+      - Replaces the previous summary comment of this action with one holding the new summary.
+      - Submits a single PR review whose inline comments are the "comments" entries. The review
+        keeps the neutral COMMENT event unless add_review_resolution is on and the "review" block
+        carries a valid resolution. Inline comments of previous runs are left in place on purpose:
+        they are collected as context on the next run, which is what keeps the review from
+        repeating itself.
     """
     if debug:
         print(summary_content)
@@ -220,30 +281,21 @@ def publish_annotations(summary_content, github_token, debug, llm_model, add_rev
         human_summary = summary_content
         technical_info_str = None
 
-    # Process the JSON block with technical information (annotations)
+    tech_info = {}
     technical_info_str = extract_json(technical_info_str)
     if technical_info_str:
         try:
             tech_info = json.loads(technical_info_str)
-            annotations = tech_info.get("annotations", [])
-            for annotation in annotations:
-                filename = annotation.get("file")
-                line = annotation.get("line")
-                message = annotation.get("message")
-                output_line = f"::warning file={filename},line={line}::{message}"
-                print(output_line)
         except json.JSONDecodeError as e:
-            print("Error parsing technical information JSON (annotations):", e)
+            print("Error parsing technical information JSON:", e)
 
-    # Post a PR comment with the human-readable summary
     g = Github(github_token)
     repo = g.get_repo(github_repo)
     pr_number = int(github_ref.split('/')[-2])
     pr = repo.get_pull(pr_number)
 
-    # Delete previous comments from GitHub Actions that include the HEADER
+    # Delete previous summary comments from GitHub Actions that include the HEADER
     for comment in pr.get_issue_comments():
-        print(comment.user.login)
         if is_previous_ai_review(comment):
             comment.delete()
 
@@ -254,21 +306,27 @@ def publish_annotations(summary_content, github_token, debug, llm_model, add_rev
 
         pr.create_issue_comment(comment)
 
-    # If a review block is present, submit a PR review via the GitHub API
-    if technical_info_str and add_review_resolution:
+    comments = tech_info.get('comments') or tech_info.get('annotations') or []
+    inline_comments = build_inline_comments(comments, collect_commentable_lines(pr.get_files()))
+
+    review_data = tech_info.get('review') or {}
+    resolution = review_data.get('resolution')
+    review_message = review_data.get('review_message', '')
+
+    event = 'COMMENT'
+    body = ''
+    if add_review_resolution:
+        if resolution in REVIEW_RESOLUTIONS:
+            event = resolution
+            body = review_message
+        else:
+            print(f"Unknown resolution '{resolution}' in review JSON. Falling back to COMMENT.")
+
+    if inline_comments or body:
         try:
-            tech_info = json.loads(technical_info_str)
-            review_data = tech_info.get("review")
-            if review_data:
-                resolution = review_data.get("resolution")
-                review_message = review_data.get("review_message", "")
-                # Validate the resolution value
-                if resolution not in ["APPROVE", "REQUEST_CHANGES", "COMMENT"]:
-                    print(f"Unknown resolution '{resolution}' in review JSON. Skipping PR review.")
-                else:
-                    pr.create_review(body=review_message, event=resolution)
-        except json.JSONDecodeError as e:
-            print("Error parsing technical information JSON (review):", e)
+            pr.create_review(body=body, event=event, comments=inline_comments)
+        except GithubException as e:
+            print("Error submitting the PR review:", e)
 
 
 def help_llm(diff_file: File):
@@ -284,10 +342,9 @@ def help_llm(diff_file: File):
         "```"
     ]
     current_line_number = None
-    hunk_header_re = re.compile(r'^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@')
 
     for line in lines:
-        match = hunk_header_re.match(line)
+        match = HUNK_HEADER_RE.match(line)
         if match:
             current_line_number = int(match.group(1))
             output_lines.append(line)
@@ -357,4 +414,4 @@ if __name__ == "__main__":
                                     pr_comments=pr_comments, review_comments=review_comments)
 
     llm_model = os.environ.get('LLM_MODEL')
-    publish_annotations(review_content, args.github_token, debug, llm_model, add_review_resolution)
+    publish_review(review_content, args.github_token, debug, llm_model, add_review_resolution)

--- a/src/ai_review/tests/test_review.py
+++ b/src/ai_review/tests/test_review.py
@@ -6,9 +6,12 @@ from pathlib import Path
 from unittest import mock
 from unittest.mock import Mock, patch
 
+from github import GithubException
 from jinja2 import Environment
 
 from ai_review.review import (
+    build_inline_comments,
+    collect_commentable_lines,
     collect_pr_comments,
     collect_review_comments,
     describe_comment_location,
@@ -20,7 +23,7 @@ from ai_review.review import (
     parse_args,
     parse_author_customization,
     process_review,
-    publish_annotations,
+    publish_review,
 )
 
 
@@ -260,8 +263,7 @@ def _issue_comment(author: str, body: str, created_at: str = '2026-01-01 10:00:0
 
 
 def _review_comment(comment_id: int, author: str, body: str, path: str = 'foo.py', line: int = 10,
-                    start_line=None, side: str = 'RIGHT', in_reply_to_id=None,
-                    original_line: int = 7, original_start_line=None):
+                    start_line=None, side: str = 'RIGHT', in_reply_to_id=None):
     comment = Mock()
     comment.id = comment_id
     comment.user = Mock(login=author)
@@ -270,8 +272,6 @@ def _review_comment(comment_id: int, author: str, body: str, path: str = 'foo.py
     comment.path = path
     comment.line = line
     comment.start_line = start_line
-    comment.original_line = original_line
-    comment.original_start_line = original_start_line
     comment.side = side
     comment.in_reply_to_id = in_reply_to_id
     comment.diff_hunk = '@@ -1,2 +1,2 @@\n-old\n+new'
@@ -376,6 +376,22 @@ def test_collect_review_comments_without_user():
     assert collect_review_comments(pr)[0]['comments'][0]['author'] == ''
 
 
+def test_collect_review_comments_skips_outdated_threads():
+    """Once the code falls out of the diff, GitHub clears `line` and the whole thread is dropped."""
+    pr = Mock()
+    pr.get_review_comments.return_value = [
+        _review_comment(1, 'alice', 'Outdated point', line=None),
+        _review_comment(2, 'bob', 'Reply to the outdated point', line=None, in_reply_to_id=1),
+        _review_comment(3, 'carol', 'Still relevant', path='bar.py', line=42),
+    ]
+
+    threads = collect_review_comments(pr)
+
+    assert len(threads) == 1
+    assert threads[0]['file'] == 'bar.py'
+    assert [c['body'] for c in threads[0]['comments']] == ['Still relevant']
+
+
 def test_describe_comment_location_single_line():
     location = describe_comment_location(_review_comment(1, 'alice', 'body', line=10))
     assert location == {'file': 'foo.py', 'line': 10, 'side': 'RIGHT'}
@@ -394,15 +410,6 @@ def test_describe_comment_location_left_side():
 def test_describe_comment_location_missing_side():
     comment = _review_comment(1, 'alice', 'body', side=None)
     assert describe_comment_location(comment)['side'] == 'RIGHT'
-
-
-def test_describe_comment_location_outdated():
-    """Once the code falls out of the diff, GitHub keeps only the original_* line numbers."""
-    comment = _review_comment(1, 'alice', 'body', line=None, original_line=7, original_start_line=5)
-
-    assert describe_comment_location(comment) == {
-        'file': 'foo.py', 'lines': '5-7', 'side': 'RIGHT', 'outdated': True
-    }
 
 
 def test_process_review_includes_comments():
@@ -456,11 +463,64 @@ def test_process_review_without_comments():
     assert context['REVIEW_COMMENTS'] == ''
 
 
+def _diff_file(filename: str = 'foo.py', patch='@@ -8,3 +8,4 @@\n context\n context\n+added\n context'):
+    diff_file = Mock()
+    diff_file.filename = filename
+    diff_file.patch = patch
+    return diff_file
+
+
+def test_collect_commentable_lines():
+    """Added and context lines of the new file version are commentable, deleted ones are not."""
+    diff_file = _diff_file(patch='@@ -8,3 +8,3 @@\n context\n-removed\n+added\n context')
+
+    assert collect_commentable_lines([diff_file]) == {'foo.py': {8, 9, 10}}
+
+
+def test_collect_commentable_lines_without_patch():
+    """A file without a patch (e.g. binary) has no commentable lines."""
+    assert collect_commentable_lines([_diff_file(patch=None)]) == {'foo.py': set()}
+
+
+def test_collect_commentable_lines_line_before_hunk_header():
+    """Diff lines arriving before any @@ header cannot be numbered, so they are not commentable."""
+    assert collect_commentable_lines([_diff_file(patch='+orphaned line')]) == {'foo.py': set()}
+
+
+def test_build_inline_comments():
+    comments = [{'file': 'foo.py', 'line': 10, 'message': 'bug: overflow'}]
+
+    assert build_inline_comments(comments, {'foo.py': {9, 10}}) == [
+        {'path': 'foo.py', 'line': 10, 'side': 'RIGHT', 'body': 'bug: overflow'}
+    ]
+
+
+def test_build_inline_comments_accepts_line_as_string():
+    comments = [{'file': 'foo.py', 'line': '10', 'message': 'bug: overflow'}]
+
+    assert build_inline_comments(comments, {'foo.py': {10}})[0]['line'] == 10
+
+
+def test_build_inline_comments_drops_invalid(capsys):
+    comments = [
+        {'file': 'foo.py', 'line': 99, 'message': 'points outside of the diff'},
+        {'file': 'unknown.py', 'line': 10, 'message': 'points at a file not in the diff'},
+        {'file': 'foo.py', 'line': 'not a number', 'message': 'has no usable line'},
+        {'file': 'foo.py', 'message': 'has no line at all'},
+        {'file': 'foo.py', 'line': 10},
+        {'line': 10, 'message': 'has no file'},
+    ]
+
+    assert build_inline_comments(comments, {'foo.py': {10}}) == []
+    assert capsys.readouterr().out.count('Skipping comment') == len(comments)
+
+
 def _make_github_mock():
     mock_github_instance = Mock()
     mock_repo = Mock()
     mock_pr = Mock()
     mock_pr.get_issue_comments.return_value = []
+    mock_pr.get_files.return_value = [_diff_file()]
     mock_github_instance.get_repo.return_value = mock_repo
     mock_repo.get_pull.return_value = mock_pr
     return mock_github_instance, mock_pr
@@ -470,12 +530,22 @@ _GITHUB_REF = 'refs/pull/1/merge'
 _GITHUB_REPO = 'owner/repo'
 
 
-def test_publish_annotations_debug(capsys):
-    mock_gh, mock_pr = _make_github_mock()
+def _publish(content, add_review_resolution=False, debug=False, mock_pr=None):
+    mock_gh, pr = _make_github_mock()
+    if mock_pr is not None:
+        pr = mock_pr
+        mock_gh.get_repo.return_value.get_pull.return_value = pr
+
     with patch('ai_review.review.Github', return_value=mock_gh), \
          patch('ai_review.review.github_ref', _GITHUB_REF), \
          patch('ai_review.review.github_repo', _GITHUB_REPO):
-        publish_annotations('Human summary', 'token', True, 'gpt-4o', False)
+        publish_review(content, 'token', debug, 'gpt-4o', add_review_resolution)
+
+    return pr
+
+
+def test_publish_review_debug(capsys):
+    mock_pr = _publish('Human summary', debug=True)
 
     out = capsys.readouterr().out
     assert 'Human summary' in out
@@ -483,46 +553,57 @@ def test_publish_annotations_debug(capsys):
     assert 'gpt-4o' in call_arg
 
 
-def test_publish_annotations_with_marker_and_annotations(capsys):
-    annotations = [{"file": "foo.py", "line": 10, "message": "Issue here"}]
-    tech_info = json.dumps({"annotations": annotations})
+def test_publish_review_posts_inline_comments():
+    comments = [{"file": "foo.py", "line": 10, "message": "bug: overflow"}]
+    tech_info = json.dumps({"comments": comments})
     content = f'Human summary\n### TECHNICAL INFORMATION\n{tech_info}'
-    mock_gh, mock_pr = _make_github_mock()
 
-    with patch('ai_review.review.Github', return_value=mock_gh), \
-         patch('ai_review.review.github_ref', _GITHUB_REF), \
-         patch('ai_review.review.github_repo', _GITHUB_REPO):
-        publish_annotations(content, 'token', False, 'gpt-4o', False)
-
-    out = capsys.readouterr().out
-    assert '::warning file=foo.py,line=10::Issue here' in out
-    mock_pr.create_issue_comment.assert_called_once()
-
-
-def test_publish_annotations_without_marker():
-    mock_gh, mock_pr = _make_github_mock()
-    with patch('ai_review.review.Github', return_value=mock_gh), \
-         patch('ai_review.review.github_ref', _GITHUB_REF), \
-         patch('ai_review.review.github_repo', _GITHUB_REPO):
-        publish_annotations('Just a human summary', 'token', False, 'gpt-4o', False)
+    mock_pr = _publish(content)
 
     mock_pr.create_issue_comment.assert_called_once()
+    mock_pr.create_review.assert_called_once_with(body='', event='COMMENT', comments=[
+        {'path': 'foo.py', 'line': 10, 'side': 'RIGHT', 'body': 'bug: overflow'}
+    ])
 
 
-def test_publish_annotations_invalid_annotations_json(capsys):
+def test_publish_review_accepts_legacy_annotations_key():
+    """The comments used to be published under the "annotations" key; it is still understood."""
+    tech_info = json.dumps({"annotations": [{"file": "foo.py", "line": 10, "message": "Issue here"}]})
+    content = f'Human summary\n### TECHNICAL INFORMATION\n{tech_info}'
+
+    mock_pr = _publish(content)
+
+    assert mock_pr.create_review.call_args[1]['comments'][0]['body'] == 'Issue here'
+
+
+def test_publish_review_skips_comment_outside_diff(capsys):
+    tech_info = json.dumps({"comments": [{"file": "foo.py", "line": 99, "message": "Issue here"}]})
+    content = f'Human summary\n### TECHNICAL INFORMATION\n{tech_info}'
+
+    mock_pr = _publish(content)
+
+    assert 'Skipping comment' in capsys.readouterr().out
+    mock_pr.create_review.assert_not_called()
+
+
+def test_publish_review_without_marker():
+    mock_pr = _publish('Just a human summary')
+
+    mock_pr.create_issue_comment.assert_called_once()
+    mock_pr.create_review.assert_not_called()
+
+
+def test_publish_review_invalid_json(capsys):
     content = 'Human summary\n### TECHNICAL INFORMATION\n{invalid json}'
-    mock_gh, _ = _make_github_mock()
 
-    with patch('ai_review.review.Github', return_value=mock_gh), \
-         patch('ai_review.review.github_ref', _GITHUB_REF), \
-         patch('ai_review.review.github_repo', _GITHUB_REPO):
-        publish_annotations(content, 'token', False, 'gpt-4o', False)
+    mock_pr = _publish(content)
 
-    assert 'Error parsing technical information JSON (annotations)' in capsys.readouterr().out
+    assert 'Error parsing technical information JSON' in capsys.readouterr().out
+    mock_pr.create_review.assert_not_called()
 
 
-def test_publish_annotations_deletes_old_bot_comments():
-    mock_gh, mock_pr = _make_github_mock()
+def test_publish_review_deletes_old_bot_comments():
+    _, mock_pr = _make_github_mock()
     bot_comment = Mock()
     bot_comment.user.login = 'github-actions[bot]'
     bot_comment.body = '# AI Review\n\nOld content'
@@ -531,80 +612,78 @@ def test_publish_annotations_deletes_old_bot_comments():
     other_comment.body = '# AI Review'
     mock_pr.get_issue_comments.return_value = [bot_comment, other_comment]
 
-    with patch('ai_review.review.Github', return_value=mock_gh), \
-         patch('ai_review.review.github_ref', _GITHUB_REF), \
-         patch('ai_review.review.github_repo', _GITHUB_REPO):
-        publish_annotations('New review', 'token', False, 'gpt-4o', False)
+    _publish('New review', mock_pr=mock_pr)
 
     bot_comment.delete.assert_called_once()
     other_comment.delete.assert_not_called()
 
 
-def test_publish_annotations_empty_summary():
+def test_publish_review_empty_summary():
     """When there is no text before the marker, human_summary is empty."""
-    tech_info = json.dumps({"annotations": []})
+    tech_info = json.dumps({"comments": []})
     content = f'### TECHNICAL INFORMATION\n{tech_info}'
-    mock_gh, mock_pr = _make_github_mock()
 
-    with patch('ai_review.review.Github', return_value=mock_gh), \
-         patch('ai_review.review.github_ref', _GITHUB_REF), \
-         patch('ai_review.review.github_repo', _GITHUB_REPO):
-        publish_annotations(content, 'token', False, 'gpt-4o', False)
+    mock_pr = _publish(content)
 
     mock_pr.create_issue_comment.assert_not_called()
 
 
-def test_publish_annotations_with_valid_review_resolution():
-    tech_info = json.dumps({"annotations": [], "review": {"resolution": "APPROVE", "review_message": "LGTM"}})
+def test_publish_review_with_valid_resolution():
+    tech_info = json.dumps({"comments": [], "review": {"resolution": "APPROVE", "review_message": "LGTM"}})
     content = f'Human summary\n### TECHNICAL INFORMATION\n{tech_info}'
-    mock_gh, mock_pr = _make_github_mock()
 
-    with patch('ai_review.review.Github', return_value=mock_gh), \
-         patch('ai_review.review.github_ref', _GITHUB_REF), \
-         patch('ai_review.review.github_repo', _GITHUB_REPO):
-        publish_annotations(content, 'token', False, 'gpt-4o', True)
+    mock_pr = _publish(content, add_review_resolution=True)
 
-    mock_pr.create_review.assert_called_once_with(body='LGTM', event='APPROVE')
+    mock_pr.create_review.assert_called_once_with(body='LGTM', event='APPROVE', comments=[])
 
 
-def test_publish_annotations_with_invalid_review_resolution(capsys):
-    tech_info = json.dumps({"annotations": [], "review": {"resolution": "UNKNOWN", "review_message": ""}})
+def test_publish_review_with_invalid_resolution(capsys):
+    tech_info = json.dumps({"comments": [], "review": {"resolution": "UNKNOWN", "review_message": ""}})
     content = f'Human summary\n### TECHNICAL INFORMATION\n{tech_info}'
-    mock_gh, mock_pr = _make_github_mock()
 
-    with patch('ai_review.review.Github', return_value=mock_gh), \
-         patch('ai_review.review.github_ref', _GITHUB_REF), \
-         patch('ai_review.review.github_repo', _GITHUB_REPO):
-        publish_annotations(content, 'token', False, 'gpt-4o', True)
+    mock_pr = _publish(content, add_review_resolution=True)
 
     assert "Unknown resolution 'UNKNOWN'" in capsys.readouterr().out
     mock_pr.create_review.assert_not_called()
 
 
-def test_publish_annotations_no_review_data():
-    """When technical info has no 'review' key, create_review is not called."""
-    tech_info = json.dumps({"annotations": []})
+def test_publish_review_invalid_resolution_still_posts_comments(capsys):
+    """A broken review block does not lose the inline comments; they go out as a plain COMMENT."""
+    tech_info = json.dumps({
+        "comments": [{"file": "foo.py", "line": 10, "message": "bug: overflow"}],
+        "review": {"resolution": "UNKNOWN", "review_message": "ignored"},
+    })
     content = f'Human summary\n### TECHNICAL INFORMATION\n{tech_info}'
-    mock_gh, mock_pr = _make_github_mock()
 
-    with patch('ai_review.review.Github', return_value=mock_gh), \
-         patch('ai_review.review.github_ref', _GITHUB_REF), \
-         patch('ai_review.review.github_repo', _GITHUB_REPO):
-        publish_annotations(content, 'token', False, 'gpt-4o', True)
+    mock_pr = _publish(content, add_review_resolution=True)
 
-    mock_pr.create_review.assert_not_called()
+    assert "Unknown resolution 'UNKNOWN'" in capsys.readouterr().out
+    assert mock_pr.create_review.call_args[1]['event'] == 'COMMENT'
 
 
-def test_publish_annotations_invalid_review_json(capsys):
-    content = 'Human summary\n### TECHNICAL INFORMATION\n{invalid json}'
-    mock_gh, _ = _make_github_mock()
+def test_publish_review_resolution_ignored_when_disabled():
+    tech_info = json.dumps({
+        "comments": [{"file": "foo.py", "line": 10, "message": "bug: overflow"}],
+        "review": {"resolution": "APPROVE", "review_message": "LGTM"},
+    })
+    content = f'Human summary\n### TECHNICAL INFORMATION\n{tech_info}'
 
-    with patch('ai_review.review.Github', return_value=mock_gh), \
-         patch('ai_review.review.github_ref', _GITHUB_REF), \
-         patch('ai_review.review.github_repo', _GITHUB_REPO):
-        publish_annotations(content, 'token', False, 'gpt-4o', True)
+    mock_pr = _publish(content, add_review_resolution=False)
 
-    assert 'Error parsing technical information JSON (review)' in capsys.readouterr().out
+    assert mock_pr.create_review.call_args[1]['event'] == 'COMMENT'
+    assert mock_pr.create_review.call_args[1]['body'] == ''
+
+
+def test_publish_review_github_error(capsys):
+    """A rejected review is reported instead of failing the whole action."""
+    tech_info = json.dumps({"comments": [{"file": "foo.py", "line": 10, "message": "bug: overflow"}]})
+    content = f'Human summary\n### TECHNICAL INFORMATION\n{tech_info}'
+    _, mock_pr = _make_github_mock()
+    mock_pr.create_review.side_effect = GithubException(422, {'message': 'Unprocessable'}, None)
+
+    _publish(content, mock_pr=mock_pr)
+
+    assert 'Error submitting the PR review' in capsys.readouterr().out
 
 
 def test_main_block():


### PR DESCRIPTION
Replace generic annotations with true GitHub review comments attached to valid diff lines, ensuring each comment appears inline on the PR. Exclude threads whose code has fallen out of the diff to keep context current and prevent misleading feedback.

This enables the action to remember prior comments, avoid repeating points, and submit a single coherent review with proper resolution states. Updated tests confirm correct handling of comment filtering, formatting, and review submission.