### PR TITLE
fix: submit bodyless APPROVE reviews to preserve resolution

### DIFF
--- a/src/ai_review/review.py
+++ b/src/ai_review/review.py
@@ -322,7 +322,9 @@ def publish_review(summary_content, github_token, debug, llm_model, add_review_r
         else:
             print(f"Unknown resolution '{resolution}' in review JSON. Falling back to COMMENT.")
 
-    if inline_comments or body:
+    # An empty APPROVE review is still submitted: unlike the other events, GitHub accepts it
+    # without a body, and dropping it would lose the resolution.
+    if inline_comments or body or event == 'APPROVE':
         try:
             pr.create_review(body=body, event=event, comments=inline_comments)
         except GithubException as e:

--- a/src/ai_review/tests/test_review.py
+++ b/src/ai_review/tests/test_review.py
@@ -637,6 +637,16 @@ def test_publish_review_with_valid_resolution():
     mock_pr.create_review.assert_called_once_with(body='LGTM', event='APPROVE', comments=[])
 
 
+def test_publish_review_bodyless_approve_is_submitted():
+    """GitHub accepts an APPROVE review without a body, so the resolution is not dropped."""
+    tech_info = json.dumps({"comments": [], "review": {"resolution": "APPROVE", "review_message": ""}})
+    content = f'Human summary\n### TECHNICAL INFORMATION\n{tech_info}'
+
+    mock_pr = _publish(content, add_review_resolution=True)
+
+    mock_pr.create_review.assert_called_once_with(body='', event='APPROVE', comments=[])
+
+
 def test_publish_review_with_invalid_resolution(capsys):
     tech_info = json.dumps({"comments": [], "review": {"resolution": "UNKNOWN", "review_message": ""}})
     content = f'Human summary\n### TECHNICAL INFORMATION\n{tech_info}'


### PR DESCRIPTION
GitHub accepts APPROVE reviews without a body, unlike other review events. Allow such bodyless APPROVE reviews to be submitted to avoid losing their resolution. Add a test to verify that an empty APPROVE review is correctly posted even when no message is provided.