### PR TITLE
fix: enforce JSON schema and enable review resolution in AI review output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           debug: true
-          add_review_resolution: false
+          add_review_resolution: true
           add_joke: true
           author_customization: |
             drew2a: "Write comments on behalf of The Oracle from The Matrix film. Use cryptic wisdom, speak about choices and paths, offer guidance in a philosophical manner, and occasionally reference concepts like destiny, the Matrix, and seeing beyond the code."

--- a/prompts/system_prompt.txt
+++ b/prompts/system_prompt.txt
@@ -43,23 +43,21 @@ When they are present:
 # Exceptions
 * Don't look at the correct/incorrect file ending
 
-# Technical Information (output as JSON, do not use any Markdown formatting for this block):
+# Output format
 
-Your output must consist of two parts:
-1. A human-readable review summary.
-2. The technical information JSON block.
-
-To ensure reliable parsing, after your review summary, output a unique marker line exactly as follows: `### TECHNICAL INFORMATION`
-
-Immediately following this marker, output the JSON object exactly as specified below.
-The JSON object must have the following structure:
+Your entire output must be a single JSON object; a response schema enforcing it is attached to the
+request. The object has the following structure:
 {
+  "summary": "<markdown review summary>",
   "comments": [ ... ],
   "review": {
       "resolution": "<APPROVE|REQUEST_CHANGES|COMMENT>",
       "review_message": "<review text>"
   }
 }
+
+The "summary" key holds the human-readable review summary. It is posted as a regular comment in
+the PR conversation, so write it as Markdown addressed to the author.
 
 The "comments" key must be an array of comment objects. Each one is posted on the pull request as
 a real review comment attached to the code, so write its message as regular Markdown addressed to
@@ -76,6 +74,7 @@ the author. Each comment object must have:
 
 Example:
 {
+  "summary": "Thanks for the PR! The change is well-scoped, but the naming in `example.js` could be clearer. See the inline comment for details.",
   "comments": [
     {"file": "example.js", "line": 10, "message": "bug [urgent]: Incorrect variable naming (Consider renaming to improve readability)\n\nsuggestion: Rename variable 'x' to a more descriptive name such as 'userCount' to better reflect its purpose in the code."}
   ],

--- a/src/ai_review/review.py
+++ b/src/ai_review/review.py
@@ -13,6 +13,41 @@ GITHUB_ACTIONS_BOT = 'github-actions[bot]'
 HEADER = '# AI Review'
 REVIEW_RESOLUTIONS = ('APPROVE', 'REQUEST_CHANGES', 'COMMENT')
 
+# Schema enforced on the LLM response, so the output needs no marker-based parsing.
+RESPONSE_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'summary': {
+            'type': 'string',
+            'description': 'Human-readable review summary in Markdown, posted as a PR comment.',
+        },
+        'comments': {
+            'type': 'array',
+            'items': {
+                'type': 'object',
+                'properties': {
+                    'file': {'type': 'string'},
+                    'line': {'type': 'integer'},
+                    'message': {'type': 'string'},
+                },
+                'required': ['file', 'line', 'message'],
+                'additionalProperties': False,
+            },
+        },
+        'review': {
+            'type': 'object',
+            'properties': {
+                'resolution': {'type': 'string', 'enum': list(REVIEW_RESOLUTIONS)},
+                'review_message': {'type': 'string'},
+            },
+            'required': ['resolution', 'review_message'],
+            'additionalProperties': False,
+        },
+    },
+    'required': ['summary', 'comments', 'review'],
+    'additionalProperties': False,
+}
+
 HUNK_HEADER_RE = re.compile(r'^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@')
 
 # Environment variables set by GitHub Actions
@@ -190,7 +225,11 @@ def process_review(title: str, body: str | None, diff_string, pr_author: str, ar
     # litellm handles api_key, base_url, api_version from env vars automatically
     response = litellm.completion(
         model=llm_model,
-        messages=messages
+        messages=messages,
+        response_format={
+            'type': 'json_schema',
+            'json_schema': {'name': 'code_review', 'strict': True, 'schema': RESPONSE_SCHEMA},
+        },
     )
 
     return response.choices[0].message.content
@@ -246,14 +285,11 @@ def build_inline_comments(comments: list[dict], commentable_lines: dict[str, set
     return inline_comments
 
 
-def publish_review(summary_content, github_token, debug, llm_model, add_review_resolution):
+def publish_review(review_content, github_token, debug, llm_model, add_review_resolution):
     """
-    Splits the LLM response into two parts:
-      1. The human-readable summary (before the marker).
-      2. The technical information after the marker ### TECHNICAL INFORMATION.
-
-    The technical information must be a JSON block with the following structure:
+    Parses the LLM response, which RESPONSE_SCHEMA constrains to a single JSON object:
     {
+      "summary": "<markdown review summary>",
       "comments": [ {"file": "<path>", "line": <line>, "message": "<markdown>"}, ... ],
       "review": {
           "resolution": "<APPROVE|REQUEST_CHANGES|COMMENT>",
@@ -270,24 +306,22 @@ def publish_review(summary_content, github_token, debug, llm_model, add_review_r
         repeating itself.
     """
     if debug:
-        print(summary_content)
+        print(review_content)
 
-    marker = "### TECHNICAL INFORMATION"
-    if marker in summary_content:
-        parts = summary_content.split(marker, 1)
-        human_summary = parts[0].strip()
-        technical_info_str = parts[1].strip()
-    else:
-        human_summary = summary_content
-        technical_info_str = None
-
-    tech_info = {}
-    technical_info_str = extract_json(technical_info_str)
-    if technical_info_str:
+    tech_info = None
+    json_str = extract_json(review_content)
+    if json_str:
         try:
-            tech_info = json.loads(technical_info_str)
+            tech_info = json.loads(json_str)
         except json.JSONDecodeError as e:
-            print("Error parsing technical information JSON:", e)
+            print("Error parsing the review JSON:", e)
+
+    if tech_info is None:
+        # The model ignored the enforced schema; its raw output is still a review worth posting.
+        tech_info = {}
+        human_summary = (review_content or '').strip()
+    else:
+        human_summary = (tech_info.get('summary') or '').strip()
 
     g = Github(github_token)
     repo = g.get_repo(github_repo)
@@ -369,7 +403,8 @@ def help_llm(diff_file: File):
 def extract_json(text):
     if not text:
         return text
-    return re.search(r'\{.*\}', text, re.DOTALL).group(0)
+    match = re.search(r'\{.*\}', text, re.DOTALL)
+    return match.group(0) if match else None
 
 
 def parse_author_customization(customization_yaml: str):

--- a/src/ai_review/tests/test_review.py
+++ b/src/ai_review/tests/test_review.py
@@ -10,6 +10,7 @@ from github import GithubException
 from jinja2 import Environment
 
 from ai_review.review import (
+    RESPONSE_SCHEMA,
     build_inline_comments,
     collect_commentable_lines,
     collect_pr_comments,
@@ -60,6 +61,10 @@ def test_process_review(mock_completion):
         {"role": 'system', "content": "prompt\nprompt"},
         {'role': 'user', 'content': 'user_prompt'}
     ]
+    assert call_kwargs['response_format'] == {
+        'type': 'json_schema',
+        'json_schema': {'name': 'code_review', 'strict': True, 'schema': RESPONSE_SCHEMA},
+    }
 
     assert 'api_key' not in call_kwargs
     assert 'base_url' not in call_kwargs
@@ -87,6 +92,7 @@ def test_extract_json():
 def test_extract_no_text():
     assert not extract_json(None)
     assert extract_json('') == ''
+    assert extract_json('plain text without json') is None
 
 
 def test_parse_author_customization_empty():
@@ -545,7 +551,8 @@ def _publish(content, add_review_resolution=False, debug=False, mock_pr=None):
 
 
 def test_publish_review_debug(capsys):
-    mock_pr = _publish('Human summary', debug=True)
+    content = json.dumps({"summary": "Human summary", "comments": []})
+    mock_pr = _publish(content, debug=True)
 
     out = capsys.readouterr().out
     assert 'Human summary' in out
@@ -555,8 +562,7 @@ def test_publish_review_debug(capsys):
 
 def test_publish_review_posts_inline_comments():
     comments = [{"file": "foo.py", "line": 10, "message": "bug: overflow"}]
-    tech_info = json.dumps({"comments": comments})
-    content = f'Human summary\n### TECHNICAL INFORMATION\n{tech_info}'
+    content = json.dumps({"summary": "Human summary", "comments": comments})
 
     mock_pr = _publish(content)
 
@@ -568,8 +574,7 @@ def test_publish_review_posts_inline_comments():
 
 def test_publish_review_accepts_legacy_annotations_key():
     """The comments used to be published under the "annotations" key; it is still understood."""
-    tech_info = json.dumps({"annotations": [{"file": "foo.py", "line": 10, "message": "Issue here"}]})
-    content = f'Human summary\n### TECHNICAL INFORMATION\n{tech_info}'
+    content = json.dumps({"annotations": [{"file": "foo.py", "line": 10, "message": "Issue here"}]})
 
     mock_pr = _publish(content)
 
@@ -577,8 +582,8 @@ def test_publish_review_accepts_legacy_annotations_key():
 
 
 def test_publish_review_skips_comment_outside_diff(capsys):
-    tech_info = json.dumps({"comments": [{"file": "foo.py", "line": 99, "message": "Issue here"}]})
-    content = f'Human summary\n### TECHNICAL INFORMATION\n{tech_info}'
+    content = json.dumps({"summary": "Human summary",
+                          "comments": [{"file": "foo.py", "line": 99, "message": "Issue here"}]})
 
     mock_pr = _publish(content)
 
@@ -586,19 +591,21 @@ def test_publish_review_skips_comment_outside_diff(capsys):
     mock_pr.create_review.assert_not_called()
 
 
-def test_publish_review_without_marker():
+def test_publish_review_plain_text_fallback():
+    """A model that ignored the schema still gets its raw output posted as the summary."""
     mock_pr = _publish('Just a human summary')
 
-    mock_pr.create_issue_comment.assert_called_once()
+    assert 'Just a human summary' in mock_pr.create_issue_comment.call_args[0][0]
     mock_pr.create_review.assert_not_called()
 
 
 def test_publish_review_invalid_json(capsys):
-    content = 'Human summary\n### TECHNICAL INFORMATION\n{invalid json}'
+    content = 'Human summary {invalid json}'
 
     mock_pr = _publish(content)
 
-    assert 'Error parsing technical information JSON' in capsys.readouterr().out
+    assert 'Error parsing the review JSON' in capsys.readouterr().out
+    assert 'Human summary' in mock_pr.create_issue_comment.call_args[0][0]
     mock_pr.create_review.assert_not_called()
 
 
@@ -619,9 +626,8 @@ def test_publish_review_deletes_old_bot_comments():
 
 
 def test_publish_review_empty_summary():
-    """When there is no text before the marker, human_summary is empty."""
-    tech_info = json.dumps({"comments": []})
-    content = f'### TECHNICAL INFORMATION\n{tech_info}'
+    """When the summary is empty, no conversation comment is posted."""
+    content = json.dumps({"summary": "", "comments": []})
 
     mock_pr = _publish(content)
 
@@ -629,8 +635,8 @@ def test_publish_review_empty_summary():
 
 
 def test_publish_review_with_valid_resolution():
-    tech_info = json.dumps({"comments": [], "review": {"resolution": "APPROVE", "review_message": "LGTM"}})
-    content = f'Human summary\n### TECHNICAL INFORMATION\n{tech_info}'
+    content = json.dumps({"summary": "Human summary", "comments": [],
+                          "review": {"resolution": "APPROVE", "review_message": "LGTM"}})
 
     mock_pr = _publish(content, add_review_resolution=True)
 
@@ -639,8 +645,8 @@ def test_publish_review_with_valid_resolution():
 
 def test_publish_review_bodyless_approve_is_submitted():
     """GitHub accepts an APPROVE review without a body, so the resolution is not dropped."""
-    tech_info = json.dumps({"comments": [], "review": {"resolution": "APPROVE", "review_message": ""}})
-    content = f'Human summary\n### TECHNICAL INFORMATION\n{tech_info}'
+    content = json.dumps({"summary": "Human summary", "comments": [],
+                          "review": {"resolution": "APPROVE", "review_message": ""}})
 
     mock_pr = _publish(content, add_review_resolution=True)
 
@@ -648,8 +654,8 @@ def test_publish_review_bodyless_approve_is_submitted():
 
 
 def test_publish_review_with_invalid_resolution(capsys):
-    tech_info = json.dumps({"comments": [], "review": {"resolution": "UNKNOWN", "review_message": ""}})
-    content = f'Human summary\n### TECHNICAL INFORMATION\n{tech_info}'
+    content = json.dumps({"summary": "Human summary", "comments": [],
+                          "review": {"resolution": "UNKNOWN", "review_message": ""}})
 
     mock_pr = _publish(content, add_review_resolution=True)
 
@@ -659,11 +665,11 @@ def test_publish_review_with_invalid_resolution(capsys):
 
 def test_publish_review_invalid_resolution_still_posts_comments(capsys):
     """A broken review block does not lose the inline comments; they go out as a plain COMMENT."""
-    tech_info = json.dumps({
+    content = json.dumps({
+        "summary": "Human summary",
         "comments": [{"file": "foo.py", "line": 10, "message": "bug: overflow"}],
         "review": {"resolution": "UNKNOWN", "review_message": "ignored"},
     })
-    content = f'Human summary\n### TECHNICAL INFORMATION\n{tech_info}'
 
     mock_pr = _publish(content, add_review_resolution=True)
 
@@ -672,11 +678,11 @@ def test_publish_review_invalid_resolution_still_posts_comments(capsys):
 
 
 def test_publish_review_resolution_ignored_when_disabled():
-    tech_info = json.dumps({
+    content = json.dumps({
+        "summary": "Human summary",
         "comments": [{"file": "foo.py", "line": 10, "message": "bug: overflow"}],
         "review": {"resolution": "APPROVE", "review_message": "LGTM"},
     })
-    content = f'Human summary\n### TECHNICAL INFORMATION\n{tech_info}'
 
     mock_pr = _publish(content, add_review_resolution=False)
 
@@ -686,8 +692,8 @@ def test_publish_review_resolution_ignored_when_disabled():
 
 def test_publish_review_github_error(capsys):
     """A rejected review is reported instead of failing the whole action."""
-    tech_info = json.dumps({"comments": [{"file": "foo.py", "line": 10, "message": "bug: overflow"}]})
-    content = f'Human summary\n### TECHNICAL INFORMATION\n{tech_info}'
+    content = json.dumps({"summary": "Human summary",
+                          "comments": [{"file": "foo.py", "line": 10, "message": "bug: overflow"}]})
     _, mock_pr = _make_github_mock()
     mock_pr.create_review.side_effect = GithubException(422, {'message': 'Unprocessable'}, None)
 


### PR DESCRIPTION
Update AI review output handling to require a single JSON object response validated against a strict schema, removing legacy marker-based parsing. Enable inclusion of review resolution states in GitHub reviews to allow automated approval, request changes, or comment submissions. Adjust workflow and tests to reflect these protocol improvements.