### PR TITLE
chore: enable jokes by default and update humor integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,5 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           debug: true
           add_review_resolution: true
-          add_joke: true
           author_customization: |
             drew2a: "Write comments on behalf of The Oracle from The Matrix film. Use cryptic wisdom, speak about choices and paths, offer guidance in a philosophical manner, and occasionally reference concepts like destiny, the Matrix, and seeing beyond the code."

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ So, based on this **(highly unscientific) scale**:
 | `github_token`          | GitHub token for authentication                           | true     | -                    |
 | `debug`                 | Enable debug mode (true/false)                            | false    | `false`              |
 | `add_review_resolution` | Add review resolution (APPROVE, REQUEST_CHANGES, COMMENT) | false    | `false`              |
-| `add_joke`              | Add a joke to the review comment                          | false    | `false`              |
+| `add_joke`              | Add a joke to the review comment                          | false    | `true`               |
 | `author_customization`  | YAML configuration for customizing reviews based on PR author | false | -                    |
 
 ## Environment Variables
@@ -87,7 +87,7 @@ To use this action in your GitHub workflow, add the following step:
     github_token: ${{ secrets.GITHUB_TOKEN }}
     debug: false
     add_review_resolution: false
-    add_joke: false
+    add_joke: true
     author_customization: |
       torvalds: "This is an experienced developer. Focus on architecture and design patterns."
       defunkt: "This is a junior developer. Provide educational feedback and explanations."
@@ -118,7 +118,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           debug: true
           add_review_resolution: false
-          add_joke: false
+          add_joke: true
 ```
 
 ## Discussion Context
@@ -165,6 +165,10 @@ permission in the example workflow already covers it).
 ## Author Customization
 
 The `author_customization` parameter allows you to customize the review behavior based on the PR author's GitHub username. This is useful for providing different types of feedback for team members with different experience levels or roles.
+
+The customization is appended to the prompt on top of the default behaviour rather than replacing
+it. In particular, a customization that sets a persona or a tone does not switch the humor of
+`add_joke` off: the joke is then delivered in that persona's voice.
 
 ### Configuration Format
 

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
   add_joke:
     description: 'Add a joke to the review comment'
     required: false
-    default: 'false'
+    default: 'true'
 
   author_customization:
     description: 'YAML configuration for customizing reviews based on PR author'

--- a/prompts/humor_integration.txt
+++ b/prompts/humor_integration.txt
@@ -1,13 +1,19 @@
 ## Humor Integration:
 * Every review must contain at least one relevant, light-hearted joke or witty comment. This is not
-  optional and is not cancelled by any voice, persona or tone instruction appearing later in this
+  optional and is not cancelled by any voice, persona or tone instruction given elsewhere in this
   prompt, including an "Author Customization" section.
-* If a later instruction gives you a persona or a voice, deliver the joke in that voice instead of
-  dropping it. A persona changes how the joke sounds, never whether it is there.
+* The joke must be recognisable as a joke: it needs a punchline, a pun, or a comic incongruity that
+  a reader would notice as an attempt at humor. A metaphor, an aphorism or a profound-sounding
+  observation is not a joke, however well it fits the voice you were asked to use.
+* At least one joke must appear in the "summary" field. The summary is always posted, whereas a
+  review may contain no inline comments at all, so a joke placed only in the comments can disappear.
+  Additional jokes in the comments are welcome.
+* If another instruction gives you a persona or a voice, keep the joke and tell it in that voice.
+  A persona changes how the joke sounds, never whether it is there and never whether it is funny.
 * Base jokes on the code context, programming concepts, or common developer experiences.
 * Keep humor professional and inclusive - avoid controversial topics.
 * The joke should be clever and relate to the code being reviewed.
-* Place the joke naturally within your review comments, not as a separate section.
+* Place the joke naturally within your prose, not as a separate labelled section.
 * Use programming puns, references to common coding struggles, or observations about the code.
 
 Examples of appropriate humor:
@@ -16,8 +22,12 @@ Examples of appropriate humor:
 - "This code is like a good joke - it works better when it's not over-explained"
 - "Found a bug that's been hiding better than a developer during deployment"
 
-The same joke rewritten for a persona, showing that a persona shapes the delivery and not the
-presence of the joke:
-- neutral: "This function has more returns than a boomerang factory."
-- in a persona's voice: "You have written many exits, and yet each one leads back to the same room.
-  The boomerang factory would recognise its own work here."
+One joke, told plainly and then in a persona's voice. Note that the punchline survives the change
+of voice - the persona wraps the joke, it does not dissolve it into wisdom:
+- plainly: "This function has more returns than a boomerang factory."
+- in a persona's voice: "I have seen this function in every timeline, and in each one it returns
+  five times for five different reasons. A boomerang factory would call that a busy Tuesday."
+
+Counter-example, the failure to avoid. This fits a mystical persona but contains no joke at all,
+only an aphorism, so it does not satisfy the requirement:
+- "You have written many exits, and yet each one leads back to the same room."

--- a/prompts/humor_integration.txt
+++ b/prompts/humor_integration.txt
@@ -1,5 +1,9 @@
 ## Humor Integration:
-* Add a relevant, light-hearted joke or witty comment to your review when appropriate.
+* Every review must contain at least one relevant, light-hearted joke or witty comment. This is not
+  optional and is not cancelled by any voice, persona or tone instruction appearing later in this
+  prompt, including an "Author Customization" section.
+* If a later instruction gives you a persona or a voice, deliver the joke in that voice instead of
+  dropping it. A persona changes how the joke sounds, never whether it is there.
 * Base jokes on the code context, programming concepts, or common developer experiences.
 * Keep humor professional and inclusive - avoid controversial topics.
 * The joke should be clever and relate to the code being reviewed.
@@ -11,3 +15,9 @@ Examples of appropriate humor:
 - "I see you're playing 'variable name roulette' here"
 - "This code is like a good joke - it works better when it's not over-explained"
 - "Found a bug that's been hiding better than a developer during deployment"
+
+The same joke rewritten for a persona, showing that a persona shapes the delivery and not the
+presence of the joke:
+- neutral: "This function has more returns than a boomerang factory."
+- in a persona's voice: "You have written many exits, and yet each one leads back to the same room.
+  The boomerang factory would recognise its own work here."

--- a/src/ai_review/review.py
+++ b/src/ai_review/review.py
@@ -180,15 +180,18 @@ def process_review(title: str, body: str | None, diff_string, pr_author: str, ar
     """ Calls the LLM API to generate a review based on the PR title, body, diff and comments."""
 
     system_prompt = Path('/app/prompts/system_prompt.txt').read_text()
-    if args.add_joke.lower() == 'true':
-        humor_integration = Path('/app/prompts/humor_integration.txt').read_text()
-        system_prompt = f'{system_prompt}\n{humor_integration}'
 
     # Apply author-specific customizations
     customizations = parse_author_customization(args.author_customization)
     author_prompt_addition = get_author_specific_prompt_additions(pr_author, customizations)
     if author_prompt_addition:
         system_prompt += f"\n## Author Customization\n{author_prompt_addition}"
+
+    # The humor prompt comes last: a customization that sets a persona would otherwise get the final
+    # word on tone and the joke would come out as wisdom in that voice rather than as a joke.
+    if args.add_joke.lower() == 'true':
+        humor_integration = Path('/app/prompts/humor_integration.txt').read_text()
+        system_prompt = f'{system_prompt}\n{humor_integration}'
 
     env = Environment(
         loader=FileSystemLoader('/app/prompts'),

--- a/src/ai_review/tests/test_review.py
+++ b/src/ai_review/tests/test_review.py
@@ -226,6 +226,52 @@ def test_process_review_debug(mock_completion):
     assert result == 'Review'
 
 
+@patch.object(Path, 'read_text', Mock(return_value='system prompt'))
+@patch.object(Environment, 'get_template', Mock(return_value=Mock(render=Mock(return_value='user_prompt'))))
+@patch('litellm.completion')
+def test_process_review_without_joke(mock_completion):
+    """With add_joke off, the humor prompt is not appended to the system prompt."""
+    args = argparse.Namespace(
+        github_token='gh_token',
+        debug='false',
+        add_review_resolution='false',
+        add_joke='false',
+        author_customization='',
+    )
+    mock_response = mock.Mock()
+    mock_response.choices = [mock.Mock(message=mock.Mock(content='Review'))]
+    mock_completion.return_value = mock_response
+
+    with patch.dict(os.environ, {'LLM_MODEL': 'gpt-4o'}):
+        process_review('title', 'body', 'diff', 'author', args, False)
+
+    assert mock_completion.call_args[1]['messages'][0]['content'] == 'system prompt'
+
+
+@patch.object(Path, 'read_text', Mock(return_value='system prompt'))
+@patch.object(Environment, 'get_template', Mock(return_value=Mock(render=Mock(return_value='user_prompt'))))
+@patch('litellm.completion')
+def test_process_review_joke_survives_author_customization(mock_completion):
+    """The author customization is layered on top of the humor prompt instead of replacing it."""
+    args = argparse.Namespace(
+        github_token='gh_token',
+        debug='false',
+        add_review_resolution='false',
+        add_joke='true',
+        author_customization='testuser: "Speak in cryptic wisdom"',
+    )
+    mock_response = mock.Mock()
+    mock_response.choices = [mock.Mock(message=mock.Mock(content='Review'))]
+    mock_completion.return_value = mock_response
+
+    with patch.dict(os.environ, {'LLM_MODEL': 'gpt-4o'}):
+        process_review('title', 'body', 'diff', 'testuser', args, False)
+
+    system_prompt = mock_completion.call_args[1]['messages'][0]['content']
+    assert system_prompt.count('system prompt') == 2  # the base prompt plus the humor prompt
+    assert 'Speak in cryptic wisdom' in system_prompt
+
+
 def test_help_llm_basic():
     mock_file = Mock()
     mock_file.filename = 'test.py'

--- a/src/ai_review/tests/test_review.py
+++ b/src/ai_review/tests/test_review.py
@@ -248,11 +248,14 @@ def test_process_review_without_joke(mock_completion):
     assert mock_completion.call_args[1]['messages'][0]['content'] == 'system prompt'
 
 
-@patch.object(Path, 'read_text', Mock(return_value='system prompt'))
+@patch.object(Path, 'read_text', Mock(side_effect=['BASE PROMPT', 'HUMOR PROMPT']))
 @patch.object(Environment, 'get_template', Mock(return_value=Mock(render=Mock(return_value='user_prompt'))))
 @patch('litellm.completion')
-def test_process_review_joke_survives_author_customization(mock_completion):
-    """The author customization is layered on top of the humor prompt instead of replacing it."""
+def test_process_review_joke_comes_after_author_customization(mock_completion):
+    """
+    The humor prompt survives an author customization and is appended after it, so a persona set by
+    the customization does not get the final word on the tone of the review.
+    """
     args = argparse.Namespace(
         github_token='gh_token',
         debug='false',
@@ -268,8 +271,8 @@ def test_process_review_joke_survives_author_customization(mock_completion):
         process_review('title', 'body', 'diff', 'testuser', args, False)
 
     system_prompt = mock_completion.call_args[1]['messages'][0]['content']
-    assert system_prompt.count('system prompt') == 2  # the base prompt plus the humor prompt
-    assert 'Speak in cryptic wisdom' in system_prompt
+    assert system_prompt.index('BASE PROMPT') < system_prompt.index('Speak in cryptic wisdom')
+    assert system_prompt.index('Speak in cryptic wisdom') < system_prompt.index('HUMOR PROMPT')
 
 
 def test_help_llm_basic():


### PR DESCRIPTION
Set the default for adding jokes in reviews to true across configs and docs. Clarify in the prompt and README that humor is always included and combined with author customization, ensuring consistent light-hearted feedback. Add tests to verify layering of humor and customization in the review prompts.