### PR TITLE
ci: use pull_request_target to enable reviews on Dependabot and forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,9 @@
 name: AI Review
-on: [ pull_request ]
+on: [ pull_request_target ]
 permissions:
   pull-requests: write
 jobs:
   review:
-    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ To use this action in your GitHub workflow, add the following step:
 ```yaml
 name: AI Code Review
 
-on: [ pull_request ]
+on: [ pull_request_target ]
 
 permissions:
   pull-requests: write
@@ -120,6 +120,27 @@ jobs:
           add_review_resolution: false
           add_joke: true
 ```
+
+### Why `pull_request_target`
+
+`pull_request` looks like the natural trigger, but GitHub strips two things from those runs when
+the PR comes from Dependabot or from a fork:
+
+- the repository secrets, so `secrets.OPENAI_API_KEY` and friends arrive empty;
+- write access, so `GITHUB_TOKEN` is read-only and the review cannot be posted. The
+  `permissions:` block does not lift this.
+
+`pull_request_target` runs the workflow in the context of the base branch, which keeps both the
+secrets and a writable token, so Dependabot and fork PRs are reviewed like any other. The usual
+warning about this trigger is that it hands a privileged token to a workflow running on untrusted
+code — that does not apply here, because `actions/checkout` checks out the *base* commit and the
+action never executes anything from the pull request. It reads the title, description, diff and
+comments through the GitHub API, and the model it sends them to has no tools. The remaining
+exposure is that the content of a PR can influence the wording of its own review.
+
+If you would rather stay on `pull_request`, the alternative is to keep the review off Dependabot
+PRs (`if: github.actor != 'dependabot[bot]'`) or to duplicate the LLM key into the separate
+Dependabot secret store and pass a PAT as `github_token`.
 
 ## Discussion Context
 

--- a/src/ai_review/review.py
+++ b/src/ai_review/review.py
@@ -53,6 +53,35 @@ HUNK_HEADER_RE = re.compile(r'^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@')
 # Environment variables set by GitHub Actions
 github_ref = os.environ.get('GITHUB_REF')
 github_repo = os.environ.get('GITHUB_REPOSITORY')
+github_event_path = os.environ.get('GITHUB_EVENT_PATH')
+
+
+def resolve_pr_number() -> int:
+    """
+    Find the number of the pull request under review.
+
+    The event payload is the primary source, because it carries the number for every trigger the
+    action can run on. GITHUB_REF holds it only for `pull_request` runs: under
+    `pull_request_target` it points at the base branch instead (`refs/heads/main`), and that is
+    the trigger needed to review PRs from Dependabot and from forks, where `pull_request` gets
+    neither the repository secrets nor a writable token.
+    """
+    if github_event_path:
+        try:
+            payload = json.loads(Path(github_event_path).read_text(encoding='utf-8'))
+            pr_number = payload['pull_request']['number']
+            return int(pr_number)
+        except (OSError, ValueError, TypeError, KeyError) as e:
+            print(f'Could not read the PR number from the event payload: {e!r}')
+
+    parts = (github_ref or '').split('/')
+    if len(parts) > 2 and parts[-2].isdigit():
+        return int(parts[-2])
+
+    raise RuntimeError(
+        f'Could not determine the pull request number '
+        f'(GITHUB_EVENT_PATH={github_event_path!r}, GITHUB_REF={github_ref!r})'
+    )
 
 
 def parse_args():
@@ -328,8 +357,7 @@ def publish_review(review_content, github_token, debug, llm_model, add_review_re
 
     g = Github(github_token)
     repo = g.get_repo(github_repo)
-    pr_number = int(github_ref.split('/')[-2])
-    pr = repo.get_pull(pr_number)
+    pr = repo.get_pull(resolve_pr_number())
 
     # Delete previous summary comments from GitHub Actions that include the HEADER
     for comment in pr.get_issue_comments():
@@ -433,8 +461,7 @@ if __name__ == "__main__":
 
     g = Github(args.github_token)
     repo = g.get_repo(github_repo)
-    pr_number = github_ref.split('/')[-2]
-    pr = repo.get_pull(int(pr_number))
+    pr = repo.get_pull(resolve_pr_number())
 
     # Get PR author information
     pr_author = pr.user.login if pr.user else ""

--- a/src/ai_review/tests/test_review.py
+++ b/src/ai_review/tests/test_review.py
@@ -25,6 +25,7 @@ from ai_review.review import (
     parse_author_customization,
     process_review,
     publish_review,
+    resolve_pr_number,
 )
 
 
@@ -593,6 +594,7 @@ def _publish(content, add_review_resolution=False, debug=False, mock_pr=None):
 
     with patch('ai_review.review.Github', return_value=mock_gh), \
          patch('ai_review.review.github_ref', _GITHUB_REF), \
+         patch('ai_review.review.github_event_path', None), \
          patch('ai_review.review.github_repo', _GITHUB_REPO):
         publish_review(content, 'token', debug, 'gpt-4o', add_review_resolution)
 
@@ -774,6 +776,7 @@ def test_main_block():
     with patch('sys.argv', ['review.py', 'gh_token', 'false', 'false', 'false', '']), \
          patch.dict(os.environ, {
              'GITHUB_REF': 'refs/pull/1/merge',
+             'GITHUB_EVENT_PATH': '',
              'GITHUB_REPOSITORY': 'owner/repo',
              'LLM_MODEL': 'gpt-4o',
          }), \
@@ -784,7 +787,55 @@ def test_main_block():
         runpy.run_module('ai_review.review', run_name='__main__')
 
     mock_pr.create_issue_comment.assert_called()
+    mock_repo.get_pull.assert_called_with(1)
 
     context = render.call_args[1]
     assert 'Please rename this' in context['PR_COMMENTS']
     assert 'This can overflow' in context['REVIEW_COMMENTS']
+
+
+def _write_event(tmp_path, payload):
+    event_file = tmp_path / 'event.json'
+    event_file.write_text(json.dumps(payload), encoding='utf-8')
+    return str(event_file)
+
+
+def test_resolve_pr_number_from_event_payload(tmp_path):
+    """The event payload wins, since it is the only source that works for every trigger."""
+    event_path = _write_event(tmp_path, {'pull_request': {'number': 42}})
+
+    with patch('ai_review.review.github_event_path', event_path), \
+         patch('ai_review.review.github_ref', 'refs/heads/main'):
+        assert resolve_pr_number() == 42
+
+
+def test_resolve_pr_number_from_ref_without_event_payload():
+    with patch('ai_review.review.github_event_path', None), \
+         patch('ai_review.review.github_ref', 'refs/pull/7/merge'):
+        assert resolve_pr_number() == 7
+
+
+def test_resolve_pr_number_falls_back_to_ref_on_unusable_payload(tmp_path, capsys):
+    """A payload without a pull request (a missing file, another event) must not be fatal."""
+    event_path = _write_event(tmp_path, {'push': {}})
+
+    with patch('ai_review.review.github_event_path', event_path), \
+         patch('ai_review.review.github_ref', 'refs/pull/7/merge'):
+        assert resolve_pr_number() == 7
+
+    assert 'Could not read the PR number' in capsys.readouterr().out
+
+    with patch('ai_review.review.github_event_path', str(tmp_path / 'missing.json')), \
+         patch('ai_review.review.github_ref', 'refs/pull/7/merge'):
+        assert resolve_pr_number() == 7
+
+
+def test_resolve_pr_number_without_any_source():
+    with patch('ai_review.review.github_event_path', None), \
+         patch('ai_review.review.github_ref', 'refs/heads/main'):
+        try:
+            resolve_pr_number()
+        except RuntimeError as e:
+            assert 'refs/heads/main' in str(e)
+        else:
+            raise AssertionError('expected a RuntimeError')


### PR DESCRIPTION
Switch the GitHub Actions trigger from `pull_request` to `pull_request_target` to retain repository secrets and a writable token when running reviews on Dependabot or forked PRs. This allows the AI review workflow to post comments and access the OpenAI API key securely in those cases.

Update review logic to extract the pull request number from the event payload instead of the ref, ensuring compatibility with the new trigger context.

Add documentation explaining why `pull_request_target` is used and tests to verify PR number resolution from event data and fallback from the ref.

This change enables consistent reviews across all PR sources without compromising security, since the code checked out is from the base branch only.