### PR TITLE
chore: add initial Dependabot workflow configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: ""
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: ""
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
Configure Dependabot to check for updates weekly to improve dependency maintenance and ensure timely awareness of new package versions. The configuration is a starting point and requires specifying package ecosystems for active monitoring.